### PR TITLE
ChatGPT UI (Playwright) primary -> Gemini 2.5 Pro fallback

### DIFF
--- a/.github/workflows/ui-automation.yml
+++ b/.github/workflows/ui-automation.yml
@@ -30,18 +30,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Install Playwright (for ChatGPT UI provider)
+        working-directory: ui-automation
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Publish 1 item (raw-genai)
         env:
-          # Prefer strongest free text provider chain
-          LLM_PROVIDER_ORDER: gemini,github_models,perplexity,openai
+          # Provider chain:
+          #   1) ChatGPT UI (Playwright) — model GPT-5.2
+          #   2) Gemini blog (2.5 Pro first)
+          #   3) Other fallbacks
+          LLM_PROVIDER_ORDER: chatgpt_ui,gemini,github_models,perplexity,openai
           DISABLE_OPENAI: 'true'
+          CHATGPT_UI_ENABLED: 'true'
+          CHATGPT_UI_MODEL_LABEL: 'GPT-5.2'
+          CHATGPT_UI_STORAGE_STATE_B64: ${{ secrets.CHATGPT_UI_STORAGE_STATE_B64 }}
+          # Ensure blog/text uses strongest Gemini first
+          GEMINI_BLOG_MODEL: gemini-2.5-pro
           VIRALOPS_PINTEREST_ALBUM_NAME: blogs
           # Secrets (set these in repo Settings → Actions → Secrets)
           GH_MODELS_API_KEY: ${{ secrets.GH_MODELS_API_KEY }}

--- a/ui-automation/scripts/chatgpt_ui.mjs
+++ b/ui-automation/scripts/chatgpt_ui.mjs
@@ -1,0 +1,132 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { chromium } from 'playwright';
+
+function readStdin() {
+  try {
+    return fs.readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function writeErr(msg) {
+  try {
+    process.stderr.write(String(msg || '') + '\n');
+  } catch {
+    // ignore
+  }
+}
+
+function b64ToFile(b64, outPath) {
+  const buf = Buffer.from(String(b64 || ''), 'base64');
+  fs.writeFileSync(outPath, buf);
+  return outPath;
+}
+
+async function main() {
+  const prompt = (readStdin() || '').trim();
+  if (!prompt) {
+    writeErr('No prompt on stdin');
+    process.exit(2);
+  }
+
+  const baseUrl = String(process.env.CHATGPT_UI_BASE_URL || 'https://chatgpt.com/').trim();
+  const modelLabel = String(process.env.CHATGPT_UI_MODEL_LABEL || 'GPT-5.2').trim();
+
+  const storageStateB64 = String(process.env.CHATGPT_UI_STORAGE_STATE_B64 || '').trim();
+  const storageStatePath = String(process.env.CHATGPT_UI_STORAGE_STATE_PATH || '').trim();
+
+  let statePath = '';
+  if (storageStatePath && fs.existsSync(storageStatePath)) {
+    statePath = storageStatePath;
+  } else if (storageStateB64) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chatgpt-state-'));
+    statePath = b64ToFile(storageStateB64, path.join(tmpDir, 'storageState.json'));
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  const context = statePath
+    ? await browser.newContext({ storageState: statePath })
+    : await browser.newContext();
+
+  const page = await context.newPage();
+
+  // Best-effort: reduce flakiness.
+  page.setDefaultTimeout(45_000);
+
+  await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
+
+  // Fail fast if not authenticated (textarea won't appear on logged-out screens).
+  const textbox = page.locator('textarea').first();
+  try {
+    await textbox.waitFor({ state: 'visible', timeout: 20_000 });
+  } catch {
+    await browser.close();
+    writeErr('Not authenticated (no chat textbox). Provide CHATGPT_UI_STORAGE_STATE_B64.');
+    process.exit(10);
+  }
+
+  // Best-effort model selection.
+  if (modelLabel) {
+    try {
+      const maybeSwitcher = page.getByRole('button', { name: /model|gpt/i }).first();
+      if (await maybeSwitcher.count()) {
+        await maybeSwitcher.click({ timeout: 3_000 });
+        const option = page.getByRole('menuitem', { name: new RegExp(modelLabel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') }).first();
+        if (await option.count()) {
+          await option.click({ timeout: 3_000 });
+        } else {
+          // Fallback: click any element containing the label.
+          const any = page.getByText(modelLabel, { exact: false }).first();
+          if (await any.count()) {
+            await any.click({ timeout: 3_000 });
+          }
+        }
+      }
+    } catch {
+      // ignore UI changes; continue with whatever default model is selected
+    }
+  }
+
+  await textbox.click();
+  await textbox.fill(prompt);
+  await textbox.press('Enter');
+
+  // Wait for an assistant message to appear.
+  const assistantMsgs = page.locator('[data-message-author-role="assistant"]');
+  await assistantMsgs.first().waitFor({ state: 'visible', timeout: 60_000 });
+
+  // Grab the last assistant message and wait for it to stabilize.
+  const last = assistantMsgs.last();
+  let prev = '';
+  let stableCount = 0;
+  for (let i = 0; i < 20; i++) {
+    const txt = (await last.innerText().catch(() => ''))?.trim() || '';
+    if (txt && txt === prev) {
+      stableCount += 1;
+      if (stableCount >= 2) break;
+    } else {
+      stableCount = 0;
+    }
+    prev = txt;
+    await page.waitForTimeout(800);
+  }
+
+  const out = (await last.innerText().catch(() => ''))?.trim() || '';
+  await browser.close();
+
+  if (!out) {
+    writeErr('Empty assistant response');
+    process.exit(11);
+  }
+
+  process.stdout.write(out);
+}
+
+main().catch((e) => {
+  writeErr(String(e?.stack || e || 'Unknown error'));
+  process.exit(1);
+});


### PR DESCRIPTION
Implements provider chatgpt_ui via Playwright automation (reads prompt from stdin, uses storageState secret) and updates Actions publish chain: chatgpt_ui -> gemini (pro-first for blog) -> other fallbacks.\n\nTo enable ChatGPT UI in CI, set secret CHATGPT_UI_STORAGE_STATE_B64 (base64 of Playwright storageState.json).